### PR TITLE
Remove `jump` class

### DIFF
--- a/src/Images/DownloadAll.ts
+++ b/src/Images/DownloadAll.ts
@@ -119,7 +119,7 @@ const DownloadAll = {
         '<label title="Persistent Download Media">' +
           '<input type="checkbox" name="Persistent Download Media"> Download media' +
         '</label>' +
-        '<a href="javascript:;" class="jump close" title="Hide">' + Icon.get('xmark') + '</a>' +
+        '<a href="javascript:;" class="close" title="Hide">' + Icon.get('xmark') + '</a>' +
       '</div>' +
       '<div class="da-body">' +
         '<div class="da-buttons">' +

--- a/src/Images/DownloadAll.ts
+++ b/src/Images/DownloadAll.ts
@@ -119,7 +119,7 @@ const DownloadAll = {
         '<label title="Persistent Download Media">' +
           '<input type="checkbox" name="Persistent Download Media"> Download media' +
         '</label>' +
-        '<a href="javascript:;" class="close" title="Hide">' + Icon.get('xmark') + '</a>' +
+        '<a href="javascript:;" class="close" title="Close">' + Icon.get('xmark') + '</a>' +
       '</div>' +
       '<div class="da-body">' +
         '<div class="da-buttons">' +


### PR DESCRIPTION
I'm going to assume this was left over when copying the `Embedding` HTML. As it stands, leaving it messes up my icon replacement technique in my userstyle and I don't feel the need to write an exception when it appears to be there erroneously in the first place.

You could probably argue that the `title` should be "Close" as opposed to "Hide" too, but I'll let you make that call.