### PR TITLE
Use tf.rita.moe for twitframe

### DIFF
--- a/src/Linkification/Embedding.tsx
+++ b/src/Linkification/Embedding.tsx
@@ -614,16 +614,16 @@ var Embedding = {
         if (Conf.XEmbedder === 'tf') {
           const el = $.el('iframe');
           $.on(el, 'load', function(this: HTMLIFrameElement) {
-            return this.contentWindow!.postMessage({element: 't', query: 'height'}, 'https://twitframe.com');
+            return this.contentWindow!.postMessage({element: 't', query: 'height'}, 'https://tf.rita.moe');
           });
           var onMessage = function(e: MessageEvent) {
-            if ((e.source === el.contentWindow) && (e.origin === 'https://twitframe.com')) {
+            if ((e.source === el.contentWindow) && (e.origin === 'https://tf.rita.moe')) {
               $.off(window, 'message', onMessage);
               return (cont || el).style.height = `${+$.minmax(e.data.height, 250, 0.8 * doc.clientHeight)}px`;
             }
           };
           $.on(window, 'message', onMessage);
-          el.src = `https://twitframe.com/show?url=https://twitter.com/${a.dataset.uid}`;
+          el.src = `https://tf.rita.moe/show?url=https://twitter.com/${a.dataset.uid}`;
           if ($.engine === 'gecko') {
             // XXX https://bugzilla.mozilla.org/show_bug.cgi?id=680823
             el.style.cssText = 'border: none; width: 100%; height: 100%;';


### PR DESCRIPTION
**Disclaimer: I own [tf.rita.moe](https://tf.rita.moe/)**
`twitframe.com` is gone, so it should probably be swapped.

I started to re-host my own version a few months ago to add support for the `x.com` domain + have settings to hide cards (`&cards=hidden`) and set the language (`&lang=en`) [(commit)](https://git.rita.moe/Rita/twitframe/commit/e79e9c03e1a7585528f5a332b343908d421622f3).
As I was hopping from various XT forks, I saw in their changelogs that they actually started to use my domain (and thus discovered 2 days ago that the original domain was gone).

Possible future improvements: be able to set the endpoint and language like we can with FxTwitter.

*Edit: I guess I should target the `beta` branch.*